### PR TITLE
Allows to limit compose of specific container service

### DIFF
--- a/src/Robo/Plugin/Commands/ContainerCommands.php
+++ b/src/Robo/Plugin/Commands/ContainerCommands.php
@@ -75,7 +75,7 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
   }
 
   /**
-   * Limit composer to specific service.
+   * Limit compose to specific service.
    *
    * @param \Robo\Contract\CommandInterface $command
    *   Docker compose commmand.

--- a/src/Robo/Plugin/Commands/ContainerCommands.php
+++ b/src/Robo/Plugin/Commands/ContainerCommands.php
@@ -15,16 +15,16 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
   /**
    * Compose all the docker containers.
    *
-   * @param string $service
-   *   Limit compose to specific container service.
+   * @param string $container
+   *   Container name, when not provided all containers are started.
    */
-  public function containersStart($service = NULL) {
+  public function containersStart($container = NULL) {
     $this->validateConfig();
     $this->title('Starting containers');
     $command = $this->taskDockerComposeUp();
 
-    if ($service) {
-      $this->limitComposeService($command, $service);
+    if ($container) {
+      $this->limitComposeContainer($command, $container);
     }
 
     $command->file($this->dockerComposeFile)
@@ -49,7 +49,7 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
    * Execute a command on a given container.
    *
    * @param string $container
-   *   Container service name.
+   *   Container name.
    * @param string $execute_command
    *   Command to execute.
    */
@@ -75,15 +75,15 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
   }
 
   /**
-   * Limit compose to specific service.
+   * Limit compose to specific container.
    *
    * @param \Robo\Contract\CommandInterface $command
    *   Docker compose commmand.
-   * @param string $service
-   *   Service name as defined on docker compose file.
+   * @param string $container
+   *   Container name as defined on docker compose file.
    */
-  private function limitComposeService(CommandInterface $command, $service) {
-    $command->setService($service);
+  private function limitComposeContainer(CommandInterface $command, $container) {
+    $command->setService($container);
   }
 
 }

--- a/src/Robo/Plugin/Commands/ContainerCommands.php
+++ b/src/Robo/Plugin/Commands/ContainerCommands.php
@@ -2,6 +2,8 @@
 
 namespace BluesparkLabs\Spark\Robo\Plugin\Commands;
 
+use Robo\Contract\CommandInterface;
+
 class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
 
   use \Droath\RoboDockerCompose\Task\loadTasks;
@@ -10,16 +12,30 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
     parent::__construct();
   }
 
-  public function containersStart() {
+  /**
+   * Compose all the docker containers.
+   *
+   * @param string $service
+   *   Limit compose to specific container service.
+   */
+  public function containersStart($service = NULL) {
     $this->validateConfig();
     $this->title('Starting containers');
-    $this->taskDockerComposeUp()
-      ->file($this->dockerComposeFile)
+    $command = $this->taskDockerComposeUp();
+
+    if ($service) {
+      $this->limitComposeService($command, $service);
+    }
+
+    $command->file($this->dockerComposeFile)
       ->projectName($this->config->get('name'))
       ->detachedMode()
       ->run();
   }
 
+  /**
+   * Destroy docker containers.
+   */
   public function containersDestroy() {
     $this->validateConfig();
     $this->title('Destroying containers');
@@ -29,6 +45,14 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
       ->run();
   }
 
+  /**
+   * Execute a command on a given container.
+   *
+   * @param string $container
+   *   Container service name.
+   * @param string $execute_command
+   *   Command to execute.
+   */
   public function containersExec($container, $execute_command) {
     $this->validateConfig();
     $this->title('Executing in container: ' . $container, FALSE);
@@ -41,9 +65,25 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
       ->run();
   }
 
+  /**
+   * Open a SSH connection to specific container.
+   */
   public function containersSsh() {
     $this->title('Logging in to PHP container');
     $this->say('This command is not implemented yet. Copy and execute the following:');
     $this->io()->text('docker-compose --file ./vendor/bluesparklabs/spark/docker/docker-compose.d8.yml --project-name \'Spark Example\' exec php bash');
   }
+
+  /**
+   * Limit composer to specific service.
+   *
+   * @param \Robo\Contract\CommandInterface $command
+   *   Docker compose commmand.
+   * @param string $service
+   *   Service name as defined on docker compose file.
+   */
+  private function limitComposeService(CommandInterface $command, $service) {
+    $command->setService($service);
+  }
+
 }


### PR DESCRIPTION
Hi @balintk, we have started to use spark to quickly setup IULD8 search solr container locally, currently we are not using the other docker container services so was a waste of resources to compose all the services from docker-compose.drupal8.yml, to avoid this problem I have implemented an argument that allows to limit the compose to one specific container service:

`composer robo containers:start solr`

Additionally I have documented the methods from ContainerCommands class. I see spark pretty useful to other commands that we have in IUL so will be passing more contributions soon. Thanks for the great work here!