### PR TITLE
Adjust Composer script name: robo → spark

### DIFF
--- a/src/Robo/Tasks.php
+++ b/src/Robo/Tasks.php
@@ -93,14 +93,14 @@ class Tasks extends \Robo\Tasks {
     foreach ($args as &$arg) {
       $arg = sprintf('"%s"', $arg);
     }
-    $this->taskExec(sprintf('composer run -d %s robo %s %s', $this->workDir, $command, implode(' ', $args)))->run();
+    $this->taskExec(sprintf('composer run -d %s spark %s %s', $this->workDir, $command, implode(' ', $args)))->run();
   }
 
   protected function taskSparkContainerExec($container, $command) {
     if (is_array($command)) {
       $command = implode('; ', $command);
     }
-    $cmd_tpl = 'composer run -d %s robo containers:exec \'%s\' \'/bin/sh -c "%s"\'';
+    $cmd_tpl = 'composer run -d %s spark containers:exec \'%s\' \'/bin/sh -c "%s"\'';
     $this->taskExec(sprintf($cmd_tpl, $this->workDir, $container, $command))->run();
   }
 


### PR DESCRIPTION
The new readme includes adding a Composer script with the name `spark`. When Spark was originally written this name was `robo`, and that’s how our tasks which we use to execute others referred to it. This breaks things if a Sparkified project is set up according to the new readme, which makes more sense, so let’s adjust how we invoke the Composer script.