### PR TITLE
Introduce environment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Toolkit to develop, test and run Drupal websites.
 
+- [Motivation, goals](#motivation-goals)
+- [Roadmap](#roadmap)
+- [Getting Started—How to Sparkify your Drupal project](#getting-started--how-to-sparkify-your-drupal-project)
+    - [Environment modes](#environment-modes)
+    - [Recommended `composer.json` bits](#recommended-composerjson-bits)
+- [Usage](#usage)
+
 ## Motivation, goals
 
 The developer team at [Bluespark](https://www.bluespark.com) have been discussing the need of a standardized local environment for a long time. We've tried a few directions over the past year or so, including an experiment with [Habitat](https://www.habitat.sh) or just relying on Docker Compose-centric solutions (i.e. [isholgueras/docker-lamp](https://github.com/isholgueras/docker-lamp) or [wodby/docker4drupal](https://github.com/wodby/docker4drupal)). The latter turned out to be a great approach, however, we had only used it as a starting point, so its maintenance across projects became challenging. Along the way we also started adding utility functions to our various wrapper scripts, so the need for organizing those in an upstream repository became clear.
@@ -19,7 +26,7 @@ The project is at an early stage, some directions are still definitely being sha
 * We're currently evaluating whether we can/should replace the environment handling and rely on [Lando](https://docs.devwithlando.io): [#4](https://github.com/BluesparkLabs/spark/issues/4);
 * There is a discussion about the viability of turning Spark into a global dependency, as opposed to requiring it on the project-level: [#5](https://github.com/BluesparkLabs/spark/issues/5).
 
-## Getting Started — How to Sparkify your Drupal project
+## Getting Started—How to Sparkify your Drupal project
 
 Check out the [Drupal 8 example project](https://github.com/BluesparkLabs/spark/tree/master/examples/drupal8).
 
@@ -50,6 +57,20 @@ Here are the main steps outlined.
 **4. Create a file named `.spark.yml` in your project's root.** This will be your project-specific configuration that Spark will use.
 
 To learn about how to write your configuration, please refer to our [`.spark.example.yml` file](https://github.com/BluesparkLabs/spark/blob/master/.spark.example.yml).
+
+**5. Create a file named `.env` in your project's root.** This will be your environment-specific configuration that Spark will use. Don't commit this file to your repository, it is meant to hold values that are not supposed to transfer between environments. Set a variable named `SPARK_MODE` inside the file. See more in the chapter about [Environment modes](#environment-modes).
+
+### Environment modes
+
+Spark can provide an environment with or without containers for PHP and the HTTP server. Our intent with that is to provide a sane—though not ideal—development environment on macOS. Those who are lucky enough to enjoy Docker on Linux can run the whole environment in containers, but developers on macOS are encouraged to set up their own PHP with a web server and leave only the rest (database, Solr etc. to Spark). (Our recommendation is to use Apache that ships with macOS and install PHP packages from https://php-osx.liip.ch.)
+
+To configure your environment mode, **create a file named `.env`** in your project's root and **set a variable named `SPARK_MODE`** to one of the following values:
+
+* `containers`
+* `containers--no-php-and-http-server`
+* `no-containers`
+
+When no containers are used, Spark will assume that PHP and the HTTP server runs locally, and your application takes care of connecting to other services, i.e. the database. `no-containers` is the fallback value when the `.env` file or the `SPARK_MODE` variable is missing.
 
 ### Recommended `composer.json` bits
 

--- a/docker/docker-compose.drupal8--no-php-and-http-server.yml
+++ b/docker/docker-compose.drupal8--no-php-and-http-server.yml
@@ -1,0 +1,34 @@
+version: '2.1'
+
+services:
+
+  db:
+    build: ./db
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: spark
+      MYSQL_USER: spark
+      MYSQL_PASSWORD: spark
+    healthcheck:
+      test: "mysqladmin -uroot -proot ping --silent"
+    volumes:
+      - "${SPARK_WORKDIR}:/opt/spark-project"
+    ports:
+      - "7501:3306"
+
+  solr:
+    build: ./solr
+    environment:
+      SOLR_HEAP: 1024m
+    volumes:
+      - "${SPARK_WORKDIR}:/opt/spark-project"
+    ports:
+      - "7502:8983"
+
+  chrome:
+    build: ./chrome
+    shm_size: '1gb'
+    ports:
+      - '9222:9222'
+    cap_add:
+      - SYS_ADMIN

--- a/examples/drupal8/.gitignore
+++ b/examples/drupal8/.gitignore
@@ -1,3 +1,4 @@
+.env
 vendor
 web/core
 web/modules/contrib

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -9,12 +9,18 @@ Getting this example site up and running
         $ cd examples/drupal8
         $ composer install
 
-2. Start Spark's containers:
+2. Create a file named .env and add the following content:
+
+        SPARK_MODE="containers"
+
+See more in the chapter about [Environment modes in Spark's readme](https://github.com/BluesparkLabs/spark#environment-modes).
+
+3. Start Spark's containers:
 
         $ composer run spark containers:start
 
-2. Install Drupal when the database container is ready:
+4. Install Drupal when the database container is ready:
 
         $ composer run spark db:check-ready && composer run spark drupal:install
 
-3. Visit http://localhost:7500 in your brower. (Username and password is *admin/admin*.)
+5. Visit http://localhost:7500 in your brower. (Username and password is *admin/admin*.)

--- a/examples/drupal8/web/sites/default/settings.php
+++ b/examples/drupal8/web/sites/default/settings.php
@@ -14,8 +14,6 @@ $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.yml';
 $settings['file_scan_ignore_directories'] = ['node_modules'];
 $settings['entity_update_batch_size'] = 50;
 
-// @todo Figure out best way to decide which settings.php to include.
-require_once(__DIR__ . '/settings.spark.php');
 $databases['default']['default'] = array (
   'database' => 'spark',
   'username' => 'spark',
@@ -29,3 +27,6 @@ $databases['default']['default'] = array (
 $settings['hash_salt'] = '0JtDW_PcXiWeKyIRpAtUu78GsI1l8qdhZd60hnPAKeauqU2jQPgx3tfFcOcUkkO4XZS1BGjaWg';
 $settings['install_profile'] = 'standard';
 $config_directories['sync'] = 'sites/default/files/config_wPhmDI7hffAVgwHkFdU_9Jjx_IMXnIwliyeOf8BZBNsYdiL87K9DFHal71kGm31moCtCOnS4-w/sync';
+
+// @todo Figure out best way to decide which settings.php to include.
+require_once(__DIR__ . '/settings.spark.php');

--- a/src/Robo/Plugin/Commands/ContainerCommands.php
+++ b/src/Robo/Plugin/Commands/ContainerCommands.php
@@ -20,6 +20,11 @@ class ContainerCommands extends \BluesparkLabs\Spark\Robo\Tasks {
    *   Container name, when not provided all containers are started.
    */
   public function containersStart($container = NULL) {
+    if ($this->getSparkMode() == 'no-containers') {
+      $this->io()->error('You are running spark in `no-containers` mode.');
+      $this->io()->note('Please set SPARK_MODE in your .env file. Documentation: https://github.com/BluesparkLabs/spark#environment-modes');
+      return;
+    }
     $this->validateConfig();
     $this->title('Starting containers');
     $command = $this->taskDockerComposeUp();

--- a/src/Robo/Plugin/Commands/DrushCommands.php
+++ b/src/Robo/Plugin/Commands/DrushCommands.php
@@ -11,7 +11,7 @@ class DrushCommands extends \BluesparkLabs\Spark\Robo\Tasks {
   private $commandBase;
 
   private function prepare() {
-    $this->isContainer = $this->containerExists('php');
+    $this->isContainer = ($this->getSparkMode() == 'containers');
     if ($this->isContainer) {
       $this->drush = '../vendor/bin/drush';
       $this->webRoot = '.';

--- a/src/Robo/Tasks.php
+++ b/src/Robo/Tasks.php
@@ -88,6 +88,26 @@ class Tasks extends \Robo\Tasks {
     }
   }
 
+  /**
+   * Return desired Spark environment.
+   *
+   * Spark can provide an environment with or without containers for PHP and
+   * the HTTP server. An environment variable named `SPARK_MODE` can be defined
+   * in a `.env` file with the following values:
+   *   * SPARK_MODE="containers"
+   *   * SPARK_MODE="containers--no-php-and-http-server"
+   *   * SPARK_MODE="no-containers"
+   *
+   * If the `.env` file is omitted or the `SPARK_MODE` variable is not set, the
+   * fallback value will be `"no-containers"`.
+   */
+  protected function getSparkMode() {
+    if ($mode = getenv('SPARK_MODE')) {
+      return $mode;
+    }
+    return 'no-containers';
+  }
+
   protected function taskSparkExec($command, $args = []) {
     // Wrap all arguments in double quotes.
     foreach ($args as &$arg) {

--- a/src/Robo/Tasks.php
+++ b/src/Robo/Tasks.php
@@ -58,6 +58,9 @@ class Tasks extends \Robo\Tasks {
       throw new \Exception('Missing configuration file: ' . Tasks::CONFIG_FILE_NAME);
     }
     $this->dockerComposeFile = './docker/docker-compose.' . $this->config->get('platform') . '.yml';
+    if ($this->getSparkMode() == 'containers--no-php-and-http-server') {
+      $this->dockerComposeFile = './docker/docker-compose.' . $this->config->get('platform') . '--no-php-and-http-server.yml';
+    }
     $this->roboExecutable = $this->workDir . '/vendor/bin/robo';
 
     $this->webRoot = $this->workDir . '/web';


### PR DESCRIPTION
This is my first attempt to support what we've been calling the "hybrid approach": when PHP and the HTTP server are handled by the host machine, and Spark is only supposed to be running containers for the database, Solr, headless Chrome and whatever we introduce later.

The idea is a simple environment variable, `SPARK_MODE` defined in the `.env` file. Then we can rely on this value inside our commands and use a different Docker Compose file and run Drush commands accordingly.

(This is a very simple approach which we may need to revisit later, but it should get us going.)