### PR TITLE
Solr config version customization and fix containers destroy.

### DIFF
--- a/docker/docker-compose.drupal8.yml
+++ b/docker/docker-compose.drupal8.yml
@@ -47,7 +47,10 @@ services:
       - "7501:3306"
 
   solr:
-    build: ./solr
+    build:
+      context: ./solr
+      args:
+        SOLR_CONFIG_VER: 8.x-2.1
     environment:
       SOLR_HEAP: 1024m
     volumes:

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -3,5 +3,25 @@ FROM wodby/drupal-solr:8-6.6-2.4.0
 USER root
 
 RUN mkdir -p /opt/spark-project
+ARG SOLR_CONFIG_VER
+RUN echo "Using SearchAPI Solr config version: $SOLR_CONFIG_VER"
+
+# Override solr config files with customization of SearchAPI Solr version that
+# cannot be customized in the parent image Dockerfile, this improved version
+# remove any previous config before move from module config directory.
+RUN set -ex; \
+    \
+    # Downloading config set from search_api_solr drupal module
+    url="https://ftp.drupal.org/files/projects/search_api_solr-${SOLR_CONFIG_VER}.tar.gz"; \
+    wget -qO- "${url}" | tar xz -C /opt/docker-solr/scripts/; \
+    mkdir -p /opt/docker-solr/configsets/drupal; \
+    rm -rf /opt/docker-solr/configsets/drupal/conf/; \
+    mv "/opt/docker-solr/scripts/search_api_solr/solr-conf/${SOLR_VER:0:1}.x" /opt/docker-solr/configsets/drupal/conf; \
+    rm -rf /opt/docker-solr/scripts/search_api_solr; \
+    chown -R $SOLR_USER:$SOLR_USER /opt/docker-solr/configsets/drupal/; \
+    \
+    # Change default config set to drupal
+    sed -i -e 's/data_driven_schema_configs/drupal/g' /usr/local/bin/actions.mk; \
+    sed -i -e 's/_default/drupal/g' /usr/local/bin/actions.mk
 
 USER $SOLR_USER


### PR DESCRIPTION
Hi @jameswilson - This pull request solves a limitation from deprecated Docker image https://github.com/wodby/drupal-solr that don't support customization of SearchAPI Solr configuration version that is used in Solr service. I tried to define SEARCH_API_SOLR_VER as environment variable and as build argument and none of those override the version that is set from the parent image at the Make script https://github.com/wodby/drupal-solr/blob/master/Makefile#L4 The new image https://github.com/wodby/solr that replace this deprecated image seems to have support to override the config version but don't wanted to do a major change in Spark at this moment due possible side effects.

Also I have resolved that Solr configuration is updated correctly handling the docker images cleaning through the containers destroy that stopped the container but don't removed the images previously created, this is some kind of cache image that is reused with previous state when docker containers are activated again after destroy so the new configuration was not applied if you have previous docker image version.

I will comment at the IUL ticket that originated this issue how to QA in local environment.